### PR TITLE
Fix right image blurriness

### DIFF
--- a/image-comparison-web/demo.css
+++ b/image-comparison-web/demo.css
@@ -45,15 +45,6 @@
           padding: 1em;
           padding-bottom: 0em;
       }
-      .demo table {
-          position: relative;
-          left: 50%;
-          -ms-transform: translate(-50%, 0);
-          -webkit-transform: translate(-50%, 0);
-          transform: translate(-50%, 0);
-          margin-left: 0;
-          margin-right: auto;
-      }
       .demo table .title {
           text-align: center;
       }


### PR DESCRIPTION
This happens with Chrome on ChromeOS at odd-width resolutions, at least.
The right image is horizontally blurred, as if scaled by width+1px.
Removing the translate(-50%, 0) appears to fix the issue. However the page
will not be centered when the window is narrower than the content, it will be
left-aligned instead. I assume this is not a big deal because it is currently not
scrollable (as per <div class="demo" style="overflow:hidden;">), so it is meant
to be viewed in full at all times anyway.
I did not check this patch with other browsers or operating systems.