### PR TITLE
comparisonfiles.json: Split "name" and "folder"

### DIFF
--- a/image-comparison-web/comparisonfiles.json
+++ b/image-comparison-web/comparisonfiles.json
@@ -4,38 +4,47 @@
             "format": [
                 {
                     "extension": "avif",
-                    "name": "AOM"
+                    "folder": "AOM",
+                    "name": "AVIF (AOM)"
                 },
                 {
                     "extension": "bpg",
+                    "folder": "BPG",
                     "name": "BPG"
                 },
                 {
                     "extension": "jxl",
+                    "folder": "JXL",
                     "name": "JXL"
                 },
                 {
                     "extension": "jpg",
+                    "folder": "MOZJPEG",
                     "name": "MOZJPEG"
                 },
                 {
                     "extension": "avif",
-                    "name": "RAV1E"
+                    "folder": "RAV1E",
+                    "name": "AVIF (RAV1E)"
                 },
                 {
                     "extension": "avif",
-                    "name": "SVT-AV1"
+                    "folder": "SVT-AV1",
+                    "name": "AVIF (SVT-AV1)"
                 },
                 {
                     "extension": "webp",
+                    "folder": "WEBP",
                     "name": "WEBP"
                 },
                 {
                     "extension": "wp2",
+                    "folder": "WEBP2",
                     "name": "WEBP2"
                 },
                 {
                     "extension": "png",
+                    "folder": "Original",
                     "name": "Original"
                 }
             ],

--- a/image-comparison-web/js/splitimage2.js
+++ b/image-comparison-web/js/splitimage2.js
@@ -383,12 +383,12 @@ window.addEventListener("load",  function (event) {
                     var optLeft = document.createElement("option");
                     var optRight = document.createElement("option");
 
-                    optLeft.setAttribute("folder", format["name"]);
+                    optLeft.setAttribute("folder", format["folder"]);
                     optLeft.text = format["name"];
                     optLeft.value = format["extension"];
                     leftSel.add(optLeft, null);
 
-                    optRight.setAttribute("folder", format["name"]);
+                    optRight.setAttribute("folder", format["folder"]);
                     optRight.text = format["name"];
                     optRight.value = format["extension"];
                     rightSel.add(optRight, null);


### PR DESCRIPTION
The goal is for "AVIF ([video codec])" to be written in the drop-down menus at eclipseo.github.io/image-comparison-web (not only "AOM" which is a video codec).