### PR TITLE
Not an orange

### DIFF
--- a/image-comparison-web/comparisonfiles.json
+++ b/image-comparison-web/comparisonfiles.json
@@ -145,7 +145,7 @@
                     "filename": "Eaglefairy_hst_big"
                 },
                 {
-                    "title": "Fruits oranges",
+                    "title": "Fruits persimmon",
                     "filename": "Fruits_oranges,_jardin_japonais_2"
                 },
                 {


### PR DESCRIPTION
I'm well aware of what it says here: https://commons.wikimedia.org/wiki/File:Fruits_oranges,_jardin_japonais_2.JPG

However this is NOT an orange, it's an American persimmon https://en.wikipedia.org/wiki/Diospyros_virginiana they really don't look alike, oranges thick skin is very different.
https://en.wikipedia.org/wiki/Diospyros_virginiana#/media/File:Persimmon.jpg


Changing this text:
![1](https://user-images.githubusercontent.com/50514477/121358684-6a8cf780-c8f8-11eb-9b76-b68027512c43.jpg)
